### PR TITLE
fix(render): adopt continuous corners for v1.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "WinIsland"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "base64 0.23.1",
  "cpal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "WinIsland"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2024"
 
 [workspace]

--- a/packaging/installer/Build-Installer.ps1
+++ b/packaging/installer/Build-Installer.ps1
@@ -72,6 +72,7 @@ New-Item -ItemType Directory -Force -Path $identityDirectory, $resourceDirectory
 Copy-Item -Path $executablePath -Destination (Join-Path $stageDirectory 'WinIsland.exe') -Force
 Copy-Item -Path (Join-Path $repositoryRoot 'resources\icon-dark.png') -Destination (Join-Path $resourceDirectory 'icon-dark.png') -Force
 Copy-Item -Path (Join-Path $repositoryRoot 'resources\icon-dark.ico') -Destination (Join-Path $resourceDirectory 'icon-dark.ico') -Force
+Copy-Item -Path (Join-Path $repositoryRoot 'resources\licenses') -Destination $resourceDirectory -Recurse -Force
 Copy-Item -Path (Join-Path $repositoryRoot 'packaging\identity\Install-Identity.ps1') -Destination (Join-Path $identityDirectory 'Install-Identity.ps1') -Force
 Copy-Item -Path (Join-Path $repositoryRoot 'packaging\identity\Remove-Identity.ps1') -Destination (Join-Path $identityDirectory 'Remove-Identity.ps1') -Force
 

--- a/packaging/installer/WinIsland.iss
+++ b/packaging/installer/WinIsland.iss
@@ -51,6 +51,7 @@ RestartApplications=no
 Source: "{#SourceDirectory}\WinIsland.exe"; DestDir: "{app}"; Flags: ignoreversion restartreplace
 Source: "{#SourceDirectory}\resources\icon-dark.png"; DestDir: "{app}\resources"; Flags: ignoreversion
 Source: "{#SourceDirectory}\resources\icon-dark.ico"; DestDir: "{app}\resources"; Flags: ignoreversion
+Source: "{#SourceDirectory}\resources\licenses\*"; DestDir: "{app}\resources\licenses"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SourceDirectory}\identity\{#IdentityPackageFile}"; DestDir: "{app}\identity"; Flags: ignoreversion
 Source: "{#SourceDirectory}\identity\{#IdentityCertificateFile}"; DestDir: "{app}\identity"; Flags: ignoreversion
 Source: "{#SourceDirectory}\identity\Install-Identity.ps1"; DestDir: "{app}\identity"; Flags: ignoreversion

--- a/resources/licenses/flutter.txt
+++ b/resources/licenses/flutter.txt
@@ -1,0 +1,25 @@
+Copyright 2014 The Flutter Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/core/render.rs
+++ b/src/core/render.rs
@@ -15,7 +15,7 @@ use crate::core::lyrics::LyricHighlight;
 use crate::core::smtc::MediaInfo;
 use crate::ui::compact::CompactOverlay;
 use crate::ui::expanded::music_view::{default_media_palette, get_media_palette};
-use crate::utils::shape::g3_rounded_rect_path;
+use crate::utils::shape::continuous_rounded_rect_path;
 use skia_safe::{ClipOp, Color, Paint, Rect, Surface, gpu::DirectContext, image_filters};
 
 pub struct LayoutParams {
@@ -107,12 +107,13 @@ pub fn draw_island(
         layout.current_w,
         layout.current_h,
     );
-    let island_path = g3_rounded_rect_path(rect, layout.current_r);
+    let island_path = continuous_rounded_rect_path(rect, layout.current_r);
     let blur_filter = if layout.sigmas.0 > MIN_BLUR_SIGMA || layout.sigmas.1 > MIN_BLUR_SIGMA {
         image_filters::blur(layout.sigmas, None, None, None)
     } else {
         None
     };
+    draw_expanded_shadow(canvas, &params, &island_path);
     draw_background_layer(canvas, direct_context, &params, rect, &island_path);
     canvas.save();
     canvas.clip_path(&island_path, ClipOp::Intersect, true);
@@ -163,6 +164,39 @@ pub fn draw_island(
     canvas.restore();
     draw_island_border(canvas, &params);
     widget_animating
+}
+
+fn draw_expanded_shadow(
+    canvas: &skia_safe::Canvas,
+    params: &DrawIslandParams<'_>,
+    island_path: &skia_safe::Path,
+) {
+    let layout = &params.layout;
+    let opacity = layout.expansion_progress.clamp(0.0, 1.0).powi(2)
+        * (1.0 - layout.hide_progress).clamp(0.0, 1.0);
+    if opacity <= MIN_VISIBLE_OPACITY {
+        return;
+    }
+    let scale = layout.expanded_scale;
+    let offset_y = 2.0 * scale;
+    let bounds = island_path.bounds();
+    let surface = canvas.image_info();
+    let margin = bounds
+        .left()
+        .min(surface.width() as f32 - bounds.right())
+        .min(bounds.top() + offset_y)
+        .min(surface.height() as f32 - bounds.bottom() - offset_y)
+        .max(0.0);
+    let sigma = (3.0 * scale).min(margin / 3.0);
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_color(Color::from_argb((28.0 * opacity) as u8, 0, 0, 0));
+    paint.set_image_filter(image_filters::blur((sigma, sigma), None, None, None));
+    canvas.save();
+    canvas.clip_path(island_path, ClipOp::Difference, true);
+    canvas.translate((0.0, offset_y));
+    canvas.draw_path(island_path, &paint);
+    canvas.restore();
 }
 
 fn draw_background_layer(
@@ -313,8 +347,18 @@ fn draw_island_border(canvas: &skia_safe::Canvas, params: &DrawIslandParams<'_>)
     } else {
         EFFECT_BORDER_ALPHA
     };
-    paint.set_color(Color::from_argb(alpha, u8::MAX, u8::MAX, u8::MAX));
-    let border_path = g3_rounded_rect_path(
+    let opacity = if params.style.island_style == SOLID_STYLE {
+        1.0 - layout.expansion_progress.clamp(0.0, 1.0)
+    } else {
+        1.0
+    };
+    paint.set_color(Color::from_argb(
+        (alpha as f32 * opacity) as u8,
+        u8::MAX,
+        u8::MAX,
+        u8::MAX,
+    ));
+    let border_path = continuous_rounded_rect_path(
         Rect::from_xywh(
             layout.island_x + BORDER_INSET,
             layout.island_y + BORDER_INSET,

--- a/src/ui/expanded/music_view.rs
+++ b/src/ui/expanded/music_view.rs
@@ -19,6 +19,7 @@ use crate::utils::cover::decode_cover_image;
 use crate::utils::font::{DrawTextCachedParams, FontManager};
 use crate::utils::physics::Spring;
 use crate::utils::scroll::{ScrollDrawParams, ScrollText};
+use crate::utils::shape::continuous_rounded_rect_path;
 use skia_safe::canvas::SrcRectConstraint;
 use skia_safe::{
     Canvas, Color, FilterMode, FontStyle, Image, MipmapMode, Paint, Point, RRect, Rect,
@@ -31,25 +32,25 @@ use std::sync::{Arc, OnceLock};
 const CONTENT_PADDING: f32 = 24.0;
 const PAGE_ARROW_RIGHT_INSET: f32 = 7.5;
 const PAGE_ARROW_FADE_RATE: f32 = 5.0;
-const COVER_SIZE: f32 = 72.0;
-const TRACK_TEXT_GAP: f32 = 16.0;
+const COVER_SIZE: f32 = 64.0;
+const TRACK_TEXT_GAP: f32 = 18.0;
 const TRACK_TEXT_RIGHT_INSET: f32 = 70.0;
 const TRACK_TITLE_BASELINE_OFFSET: f32 = 26.0;
-const PROGRESS_TOP_GAP: f32 = 18.0;
+const PROGRESS_TOP_GAP: f32 = 24.0;
 const PROGRESS_TIME_FONT_SCALE: f32 = 0.67;
 const DEFAULT_PROGRESS_TIME_FONT_SIZE: f32 = 10.0;
-const PROGRESS_TIME_WIDTH: f32 = 36.0;
+const PROGRESS_TIME_WIDTH: f32 = 28.0;
 const PROGRESS_TIME_GAP: f32 = 4.0;
 const PROGRESS_START_THRESHOLD: f32 = 0.02;
 const PROGRESS_JUMP_THRESHOLD: f32 = 0.3;
 const PROGRESS_SMOOTHING: f32 = 0.15;
 const PROGRESS_HOVER_SMOOTHING: f32 = 0.18;
 const PROGRESS_HOVER_SNAP_THRESHOLD: f32 = 0.005;
-const PROGRESS_BAR_HEIGHT: f32 = 5.5;
+const PROGRESS_BAR_HEIGHT: f32 = 6.5;
 const PROGRESS_BAR_HOVER_GROWTH: f32 = 3.5;
 const PROGRESS_TIME_BASELINE_SCALE: f32 = 0.35;
 const PROGRESS_TIME_IDLE_ALPHA: f32 = 0.5;
-const PROGRESS_TRACK_ALPHA: f32 = 0.25;
+const PROGRESS_TRACK_ALPHA: f32 = 0.15;
 const PLAYBACK_CONTROLS_TOP_GAP: f32 = 42.0;
 const SKIP_BUTTON_GAP: f32 = 75.0;
 const SKIP_ANIMATION_DURATION_SECS: f32 = 0.5;
@@ -653,11 +654,10 @@ fn draw_cover(params: CoverParams) -> f32 {
         canvas.save_layer(&skia_safe::canvas::SaveLayerRec::default().paint(&blur_paint));
     }
 
-    canvas.clip_rrect(
-        RRect::new_rect_xy(
+    canvas.clip_path(
+        &continuous_rounded_rect_path(
             Rect::from_xywh(img_x, img_y, img_size, img_size),
-            14.0 * scale,
-            14.0 * scale,
+            16.0 * scale,
         ),
         skia_safe::ClipOp::Intersect,
         true,

--- a/src/ui/expanded/music_view/controls.rs
+++ b/src/ui/expanded/music_view/controls.rs
@@ -1,9 +1,10 @@
 use crate::core::smtc::MediaInfo;
 
 use super::{
-    CONTENT_PADDING, COVER_FLIP_ANIM, COVER_FLIP_OLD_IMG, IMG_CACHE, LOCAL_PLAY_STATE,
-    NEXT_SKIP_ANIM, PAUSE_CONTROL_PRESS_VELOCITY, PAUSE_SPRING, PREV_SKIP_ANIM, PROGRESS_DRAGGING,
-    PROGRESS_HOVER, PROGRESS_SMOOTH,
+    CONTENT_PADDING, COVER_FLIP_ANIM, COVER_FLIP_OLD_IMG, COVER_SIZE, IMG_CACHE, LOCAL_PLAY_STATE,
+    NEXT_SKIP_ANIM, PAUSE_CONTROL_PRESS_VELOCITY, PAUSE_SPRING, PLAYBACK_CONTROLS_TOP_GAP,
+    PREV_SKIP_ANIM, PROGRESS_DRAGGING, PROGRESS_HOVER, PROGRESS_SMOOTH, PROGRESS_TIME_GAP,
+    PROGRESS_TIME_WIDTH, PROGRESS_TOP_GAP, SKIP_BUTTON_GAP,
 };
 
 pub fn set_progress_dragging(active: bool) {
@@ -72,9 +73,9 @@ pub fn get_pause_btn_rect(
     scale: f32,
     _cover_shape: &str,
 ) -> (f32, f32, f32, f32) {
-    let (img_size, img_y) = (72.0 * scale, oy + 24.0 * scale);
-    let bar_y = img_y + img_size + 18.0 * scale;
-    let btn_cy = bar_y + 42.0 * scale;
+    let (img_size, img_y) = (COVER_SIZE * scale, oy + CONTENT_PADDING * scale);
+    let bar_y = img_y + img_size + PROGRESS_TOP_GAP * scale;
+    let btn_cy = bar_y + PLAYBACK_CONTROLS_TOP_GAP * scale;
     let hit = 40.0 * scale;
     let btn_cx = ox + w / 2.0;
     (btn_cx - hit / 2.0, btn_cy - hit / 2.0, hit, hit)
@@ -88,11 +89,11 @@ pub fn get_prev_btn_rect(
     scale: f32,
     _cover_shape: &str,
 ) -> (f32, f32, f32, f32) {
-    let (img_size, img_y) = (72.0 * scale, oy + 24.0 * scale);
-    let bar_y = img_y + img_size + 18.0 * scale;
-    let btn_cy = bar_y + 42.0 * scale;
+    let (img_size, img_y) = (COVER_SIZE * scale, oy + CONTENT_PADDING * scale);
+    let bar_y = img_y + img_size + PROGRESS_TOP_GAP * scale;
+    let btn_cy = bar_y + PLAYBACK_CONTROLS_TOP_GAP * scale;
     let hit = 36.0 * scale;
-    let btn_cx = ox + w / 2.0 - 75.0 * scale;
+    let btn_cx = ox + w / 2.0 - SKIP_BUTTON_GAP * scale;
     (btn_cx - hit / 2.0, btn_cy - hit / 2.0, hit, hit)
 }
 
@@ -104,11 +105,11 @@ pub fn get_next_btn_rect(
     scale: f32,
     _cover_shape: &str,
 ) -> (f32, f32, f32, f32) {
-    let (img_size, img_y) = (72.0 * scale, oy + 24.0 * scale);
-    let bar_y = img_y + img_size + 18.0 * scale;
-    let btn_cy = bar_y + 42.0 * scale;
+    let (img_size, img_y) = (COVER_SIZE * scale, oy + CONTENT_PADDING * scale);
+    let bar_y = img_y + img_size + PROGRESS_TOP_GAP * scale;
+    let btn_cy = bar_y + PLAYBACK_CONTROLS_TOP_GAP * scale;
     let hit = 36.0 * scale;
-    let btn_cx = ox + w / 2.0 + 75.0 * scale;
+    let btn_cx = ox + w / 2.0 + SKIP_BUTTON_GAP * scale;
     (btn_cx - hit / 2.0, btn_cy - hit / 2.0, hit, hit)
 }
 
@@ -124,13 +125,13 @@ pub fn get_progress_bar_rect(
     if !music_active {
         return None;
     }
-    let (img_size, img_y) = (72.0 * scale, oy + 24.0 * scale);
-    let bar_y = img_y + img_size + 18.0 * scale;
-    let time_w = 36.0 * scale;
+    let (img_size, img_y) = (COVER_SIZE * scale, oy + CONTENT_PADDING * scale);
+    let bar_y = img_y + img_size + PROGRESS_TOP_GAP * scale;
+    let time_w = PROGRESS_TIME_WIDTH * scale;
     let bar_full_left = ox + CONTENT_PADDING * scale;
     let bar_full_right = ox + w - CONTENT_PADDING * scale;
-    let bar_left = bar_full_left + time_w + 4.0 * scale;
-    let bar_right = bar_full_right - time_w - 4.0 * scale;
+    let bar_left = bar_full_left + time_w + PROGRESS_TIME_GAP * scale;
+    let bar_right = bar_full_right - time_w - PROGRESS_TIME_GAP * scale;
     let hit_h = 16.0 * scale;
     Some((bar_left, bar_right, bar_y - hit_h / 2.0, hit_h))
 }

--- a/src/ui/widget/expanded/mod.rs
+++ b/src/ui/widget/expanded/mod.rs
@@ -5,6 +5,7 @@ pub mod time;
 
 use crate::core::config::{WIDGET_GRID_COLS, WIDGET_GRID_ROWS, WidgetKind, widget_footprint};
 use crate::utils::font::FontManager;
+use crate::utils::shape::{continuous_rounded_rect_path, expanded_island_radius};
 use skia_safe::{Canvas, Color, Paint, Rect};
 
 #[derive(Debug, Clone, Copy)]
@@ -68,7 +69,9 @@ impl WidgetGridLayout {
 }
 
 pub fn widget_grid_layout(x: f32, y: f32, w: f32, h: f32, scale: f32) -> WidgetGridLayout {
-    let inset = 12.0 * scale;
+    let radius = expanded_island_radius(w, h, scale);
+    let corner_inset = radius * (1.0 - std::f32::consts::FRAC_1_SQRT_2);
+    let inset = (corner_inset + 8.0 * scale).max(24.0 * scale);
     let gap = 7.0 * scale;
     let inner_w = (w - inset * 2.0).max(0.0);
     let inner_h = (h - inset * 2.0).max(0.0);
@@ -98,14 +101,15 @@ pub(crate) fn draw_widget_rounded_background(
     background.set_color(Color::from_argb((alpha as f32 * 0.05) as u8, 28, 28, 30));
     let rect = Rect::from_xywh(x, y, w, h);
     let radius = widget_corner_radius(w, h, scale);
-    canvas.draw_round_rect(rect, radius, radius, &background);
+    let path = continuous_rounded_rect_path(rect, radius);
+    canvas.draw_path(&path, &background);
 
     let mut border = Paint::default();
     border.set_anti_alias(true);
     border.set_style(skia_safe::paint::Style::Stroke);
     border.set_stroke_width(1.0 * scale);
     border.set_color(Color::from_argb((alpha as f32 * 0.16) as u8, 255, 255, 255));
-    canvas.draw_round_rect(rect, radius, radius, &border);
+    canvas.draw_path(&path, &border);
 }
 
 pub(crate) fn widget_corner_radius(w: f32, h: f32, scale: f32) -> f32 {

--- a/src/utils/mouse.rs
+++ b/src/utils/mouse.rs
@@ -8,7 +8,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
     GetWindowRect, GetWindowThreadProcessId, IsIconic,
 };
 
-use crate::utils::shape::g3_corner_contains;
+use crate::utils::shape::continuous_rounded_rect_path;
 
 pub fn get_global_cursor_pos() -> (i32, i32) {
     let mut point = POINT::default();
@@ -24,7 +24,7 @@ pub fn is_point_in_rect(px: f64, py: f64, rx: f64, ry: f64, rw: f64, rh: f64) ->
     px >= rx && px <= rx + rw && py >= ry && py <= ry + rh
 }
 
-pub fn is_point_in_g3_rounded_rect(
+pub fn is_point_in_continuous_rounded_rect(
     px: f64,
     py: f64,
     rx: f64,
@@ -47,15 +47,11 @@ pub fn is_point_in_g3_rounded_rect(
         return false;
     }
 
-    let half_w = rw / 2.0;
-    let half_h = rh / 2.0;
-    let radius = radius.max(0.0).min(half_w.min(half_h));
-    if radius == 0.0 {
-        return true;
-    }
-    let dx = ((px - (rx + half_w)).abs() - (half_w - radius)).max(0.0);
-    let dy = ((py - (ry + half_h)).abs() - (half_h - radius)).max(0.0);
-    g3_corner_contains(dx / radius, dy / radius)
+    continuous_rounded_rect_path(
+        skia_safe::Rect::from_xywh(rx as f32, ry as f32, rw as f32, rh as f32),
+        radius as f32,
+    )
+    .contains(skia_safe::Point::new(px as f32, py as f32))
 }
 
 pub fn is_left_button_pressed() -> bool {

--- a/src/utils/settings_ui/renderer/widget_preview.rs
+++ b/src/utils/settings_ui/renderer/widget_preview.rs
@@ -12,7 +12,7 @@ use crate::ui::widget::expanded::{
 };
 use crate::utils::color::SettingsTheme;
 use crate::utils::settings_ui::{SettingsPainter, settings_paint};
-use crate::utils::shape::g3_rounded_rect_path;
+use crate::utils::shape::{continuous_rounded_rect_path, expanded_island_radius};
 
 use super::super::input::{
     COMPACT_WIDGET_ISLAND_PANEL_H, COMPACT_WIDGET_PREVIEW_H, CompactWidgetGridGeom,
@@ -99,7 +99,7 @@ fn draw_island_background(
     let mut shadow = Paint::default();
     shadow.set_anti_alias(true);
     shadow.set_color(Color::from_argb(72, 0, 0, 0));
-    let shadow_path = g3_rounded_rect_path(
+    let shadow_path = continuous_rounded_rect_path(
         Rect::from_xywh(rect.left, rect.top + 4.0, rect.width(), rect.height()),
         corner_radius,
     );
@@ -138,7 +138,7 @@ fn draw_island_background(
     } else {
         paint.set_color(Color::from_rgb(10, 10, 10));
     }
-    let island_path = g3_rounded_rect_path(rect, corner_radius);
+    let island_path = continuous_rounded_rect_path(rect, corner_radius);
     canvas.draw_path(&island_path, &paint);
 
     paint.set_shader(None);
@@ -175,12 +175,8 @@ fn draw_grid(
         ));
         paint.set_style(skia_safe::paint::Style::Stroke);
         paint.set_stroke_width(if dragging { 1.0 } else { 0.75 });
-        canvas.draw_round_rect(
-            Rect::from_xywh(x, y, width, height),
-            slot_radius,
-            slot_radius,
-            &paint,
-        );
+        let path = continuous_rounded_rect_path(Rect::from_xywh(x, y, width, height), slot_radius);
+        canvas.draw_path(&path, &paint);
     }
 
     for slot in drop_cells {
@@ -192,11 +188,11 @@ fn draw_grid(
             theme.accent.g(),
             theme.accent.b(),
         ));
-        canvas.draw_round_rect(rect, slot_radius, slot_radius, &paint);
+        canvas.draw_path(&continuous_rounded_rect_path(rect, slot_radius), &paint);
         paint.set_style(skia_safe::paint::Style::Stroke);
         paint.set_stroke_width(2.0);
         paint.set_color(theme.accent);
-        canvas.draw_round_rect(rect, slot_radius, slot_radius, &paint);
+        canvas.draw_path(&continuous_rounded_rect_path(rect, slot_radius), &paint);
     }
 }
 
@@ -445,7 +441,13 @@ fn draw_expanded_widget_preview(params: WidgetPreviewParams<'_>) {
         geometry.cap_w,
         geometry.cap_h,
     );
-    draw_island_background(canvas, island_rect, island_style, theme, 28.0);
+    draw_island_background(
+        canvas,
+        island_rect,
+        island_style,
+        theme,
+        expanded_island_radius(geometry.cap_w, geometry.cap_h, geometry.cap_scale),
+    );
 
     let dragging = widget_dragging.is_some();
     let drop_cells = match (widget_dragging, widget_drag_hover_slot) {
@@ -542,7 +544,7 @@ fn draw_compact_grid(
         return;
     }
     canvas.save();
-    let island_path = g3_rounded_rect_path(
+    let island_path = continuous_rounded_rect_path(
         Rect::from_xywh(
             geometry.cap_x,
             geometry.cap_y,

--- a/src/utils/shape.rs
+++ b/src/utils/shape.rs
@@ -1,20 +1,146 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Rounded-superellipse geometry adapted from Flutter under the BSD-3-Clause license.
+// See resources/licenses/flutter.txt.
+
 use std::cell::RefCell;
 use std::collections::VecDeque;
-use std::sync::OnceLock;
 
 use skia_safe::{Path, PathBuilder, Rect};
 
-const G3_BLEND_EXTENT: f32 = 0.3;
-const G3_BLEND_SEGMENTS: usize = 8;
-const CORNER_COUNT: usize = 4;
-const PATH_CACHE_CAPACITY: usize = 8;
+const PATH_CACHE_CAPACITY: usize = 64;
+type CurvePoint = (f64, f64);
 
-struct G3Geometry {
-    blend_coefficients: [f32; 4],
-    blend_points: [(f32, f32); G3_BLEND_SEGMENTS],
-    arc_control: (f32, f32),
-    arc_end: (f32, f32),
-    arc_weight: f32,
+struct Octant {
+    points: [CurvePoint; 8],
+    weights: [f32; 2],
+}
+
+fn interpolate(table: &[(f64, f64)], position: f64) -> (f64, f64) {
+    let position = position.clamp(0.0, (table.len() - 1) as f64);
+    let index = (position.floor() as usize).min(table.len() - 2);
+    let fraction = position - index as f64;
+    (
+        table[index].0 + (table[index + 1].0 - table[index].0) * fraction,
+        table[index].1 + (table[index + 1].1 - table[index].1) * fraction,
+    )
+}
+
+fn superellipse_parameters(ratio: f64) -> (f64, f64) {
+    const PARAMETERS: [(f64, f64); 11] = [
+        (2.0, 1.13276676),
+        (2.18349805, 1.20311921),
+        (2.33888662, 1.28698796),
+        (2.48660575, 1.36351941),
+        (2.62226596, 1.44717976),
+        (2.75148990, 1.53385819),
+        (3.36298265, 1.98288283),
+        (4.08649929, 2.23811846),
+        (4.85481134, 2.47563463),
+        (5.62945551, 2.72948597),
+        (6.43023796, 2.98020421),
+    ];
+    let (exponent, factor) = if ratio > 5.0 {
+        (
+            6.43023796 + 1.559599389 * (ratio - 5.0),
+            2.98020421 + 0.522807185 * (ratio - 5.0),
+        )
+    } else {
+        let position = if ratio < 2.5 {
+            (ratio - 2.0) * 10.0
+        } else {
+            5.0 + (ratio - 2.5) * 2.0
+        };
+        interpolate(&PARAMETERS, position)
+    };
+    (exponent, 1.0 - 1.0 / factor)
+}
+
+fn tangent_intersection(a: CurvePoint, slope_a: f64, b: CurvePoint, slope_b: f64) -> CurvePoint {
+    if (slope_a - slope_b).abs() < 1e-5 {
+        return ((a.0 + b.0) / 2.0, (a.1 + b.1) / 2.0);
+    }
+    let x = (slope_a * a.0 - slope_b * b.0 + b.1 - a.1) / (slope_a - slope_b);
+    (x, slope_a * (x - a.0) + a.1)
+}
+
+impl Octant {
+    fn new(a: f64, radius: f64) -> Self {
+        const BEZIER_FACTORS: [(f64, f64); 13] = [
+            (0.7078, 8.3194),
+            (0.7895, 2.4523),
+            (0.8379, 1.8528),
+            (0.8701, 1.6891),
+            (0.8932, 1.5806),
+            (0.9107, 1.5043),
+            (0.9244, 1.4470),
+            (0.9355, 1.4037),
+            (0.9448, 1.3701),
+            (0.9526, 1.3431),
+            (0.9594, 1.3212),
+            (0.9653, 1.3032),
+            (0.9705, 1.2880),
+        ];
+        let (n, x_ratio) = superellipse_parameters(2.0 * a / radius);
+        let start = (0.0, a);
+        let join = (x_ratio * a, (1.0 - x_ratio.powf(n)).powf(1.0 / n) * a);
+        let gap = (1.0 - std::f64::consts::FRAC_1_SQRT_2) * radius;
+        let end = (a - gap, a - gap);
+        let slope = (join.0 / join.1).powf(n - 1.0);
+        let d = (join.0 - slope * join.1) / (1.0 - slope);
+        let circle_radius = (a - d - gap) * std::f64::consts::SQRT_2;
+        let delta = (end.0 - join.0, end.1 - join.1);
+        let chord = delta.0.hypot(delta.1);
+        let distance = (circle_radius * circle_radius - chord * chord / 4.0)
+            .max(0.0)
+            .sqrt();
+        let center = (
+            (join.0 + end.0) / 2.0 + delta.1 / chord * distance,
+            (join.1 + end.1) / 2.0 - delta.0 / chord * distance,
+        );
+        let v0 = (join.0 - center.0, join.1 - center.1);
+        let v1 = (end.0 - center.0, end.1 - center.1);
+        let angle = (v1.0 * v0.1 - v1.1 * v0.0).atan2(v1.0 * v0.0 + v1.1 * v0.1);
+        let factor = (angle / 4.0).tan() * 4.0 / 3.0;
+        let c1 = (join.0 + v0.1 * factor, join.1 - v0.0 * factor);
+        let c2 = (end.0 - v1.1 * factor, end.1 + v1.0 * factor);
+        let limited_n = n.min(14.0);
+        let (weight1, weight2) = interpolate(&BEZIER_FACTORS, limited_n - 2.0);
+        let root_n = limited_n.sqrt();
+        let y_mid = (root_n + join.1 / a) / (root_n + 1.0);
+        let midpoint = ((1.0 - y_mid.powf(n)).powf(1.0 / n) * a, y_mid * a);
+        let mid_slope = -(midpoint.0 / midpoint.1).powf(n - 1.0);
+        Self {
+            points: [
+                start,
+                tangent_intersection(start, 0.0, midpoint, mid_slope),
+                midpoint,
+                tangent_intersection(midpoint, mid_slope, join, -slope),
+                join,
+                c1,
+                c2,
+                end,
+            ],
+            weights: [(weight1 * root_n) as f32, (weight2 * x_ratio) as f32],
+        }
+    }
+
+    fn append(
+        &self,
+        builder: &mut PathBuilder,
+        map: impl Fn(CurvePoint) -> (f32, f32),
+        reverse: bool,
+    ) {
+        let [start, c1, midpoint, c2, join, arc1, arc2, end] = self.points;
+        if reverse {
+            builder.cubic_to(map(arc2), map(arc1), map(join));
+            builder.conic_to(map(c2), map(midpoint), self.weights[1]);
+            builder.conic_to(map(c1), map(start), self.weights[0]);
+        } else {
+            builder.conic_to(map(c1), map(midpoint), self.weights[0]);
+            builder.conic_to(map(c2), map(join), self.weights[1]);
+            builder.cubic_to(map(arc1), map(arc2), map(end));
+        }
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -35,92 +161,11 @@ thread_local! {
     static PATH_CACHE: RefCell<VecDeque<CachedPath>> = const { RefCell::new(VecDeque::new()) };
 }
 
-fn evaluate_blend(x: f32, coefficients: [f32; 4]) -> f32 {
-    let t = (x / G3_BLEND_EXTENT).clamp(0.0, 1.0);
-    let t2 = t * t;
-    let [a4, a5, a6, a7] = coefficients;
-    t2 * t2 * (a4 + t * (a5 + t * (a6 + t * a7)))
+pub(crate) fn expanded_island_radius(w: f32, h: f32, scale: f32) -> f32 {
+    (48.0 * scale).min(w / 2.0).min(h / 2.0).max(0.0)
 }
 
-fn solve_g3_blend_coefficients(
-    position: f32,
-    slope: f32,
-    curvature: f32,
-    curvature_rate: f32,
-) -> [f32; 4] {
-    [
-        35.0 * position - 15.0 * slope + 2.5 * curvature - curvature_rate / 6.0,
-        -84.0 * position + 39.0 * slope - 7.0 * curvature + curvature_rate / 2.0,
-        70.0 * position - 34.0 * slope + 6.5 * curvature - curvature_rate / 2.0,
-        -20.0 * position + 10.0 * slope - 2.0 * curvature + curvature_rate / 6.0,
-    ]
-}
-
-fn g3_geometry() -> &'static G3Geometry {
-    static GEOMETRY: OnceLock<G3Geometry> = OnceLock::new();
-    GEOMETRY.get_or_init(|| {
-        let extent = G3_BLEND_EXTENT;
-        let circle_root = (1.0 - extent * extent).sqrt();
-        let position = 1.0 - circle_root;
-        let slope = extent * extent / circle_root;
-        let curvature = extent * extent / circle_root.powi(3);
-        let curvature_rate = 3.0 * extent.powi(4) / circle_root.powi(5);
-        let blend_coefficients =
-            solve_g3_blend_coefficients(position, slope, curvature, curvature_rate);
-        let blend_points = std::array::from_fn(|index| {
-            let x = extent * (index + 1) as f32 / G3_BLEND_SEGMENTS as f32;
-            (x, evaluate_blend(x, blend_coefficients))
-        });
-        let arc_sweep = std::f32::consts::FRAC_PI_2 - 2.0 * extent.asin();
-        let arc_weight = (arc_sweep / 2.0).cos();
-        let control_x = std::f32::consts::FRAC_1_SQRT_2 / arc_weight;
-
-        G3Geometry {
-            blend_coefficients,
-            blend_points,
-            arc_control: (control_x, 1.0 - control_x),
-            arc_end: (circle_root, 1.0 - extent),
-            arc_weight,
-        }
-    })
-}
-
-fn g3_blend_y(x: f32) -> f32 {
-    evaluate_blend(x, g3_geometry().blend_coefficients)
-}
-
-fn append_g3_corner(builder: &mut PathBuilder, point_at: impl Fn(f32, f32) -> (f32, f32)) {
-    let geometry = g3_geometry();
-    for (x, y) in geometry.blend_points {
-        builder.line_to(point_at(x, y));
-    }
-
-    builder.conic_to(
-        point_at(geometry.arc_control.0, geometry.arc_control.1),
-        point_at(geometry.arc_end.0, geometry.arc_end.1),
-        geometry.arc_weight,
-    );
-
-    for (x, y) in geometry.blend_points.into_iter().rev() {
-        if x < G3_BLEND_EXTENT {
-            builder.line_to(point_at(1.0 - y, 1.0 - x));
-        }
-    }
-    builder.line_to(point_at(1.0, 1.0));
-}
-
-pub(crate) fn g3_corner_contains(x: f64, y: f64) -> bool {
-    let extent = G3_BLEND_EXTENT as f64;
-    if x <= extent {
-        1.0 - y >= g3_blend_y(x as f32) as f64
-    } else if y <= extent {
-        1.0 - x >= g3_blend_y(y as f32) as f64
-    } else {
-        x * x + y * y <= 1.0
-    }
-}
-
-pub(crate) fn g3_rounded_rect_path(rect: Rect, radius: f32) -> Path {
+pub(crate) fn continuous_rounded_rect_path(rect: Rect, radius: f32) -> Path {
     if !rect.is_finite() || rect.width() <= 0.0 || rect.height() <= 0.0 {
         return Path::default();
     }
@@ -150,35 +195,38 @@ pub(crate) fn g3_rounded_rect_path(rect: Rect, radius: f32) -> Path {
     if radius == 0.0 {
         builder.add_rect(rect, None, None);
     } else {
-        let left = rect.left();
-        let top = rect.top();
-        let right = rect.right();
-        let bottom = rect.bottom();
-
-        let points_per_corner = G3_BLEND_SEGMENTS * 2 + 2;
-        let verbs_per_corner = G3_BLEND_SEGMENTS * 2 + 1;
-        builder.inc_reserve(
-            1 + CORNER_COUNT + CORNER_COUNT * points_per_corner,
-            2 + CORNER_COUNT + CORNER_COUNT * verbs_per_corner,
-            CORNER_COUNT,
-        );
-        builder.move_to((left + radius, top));
-        builder.line_to((right - radius, top));
-        append_g3_corner(&mut builder, |x, y| {
-            (right - radius + radius * x, top + radius * y)
-        });
-        builder.line_to((right, bottom - radius));
-        append_g3_corner(&mut builder, |x, y| {
-            (right - radius * y, bottom - radius + radius * x)
-        });
-        builder.line_to((left + radius, bottom));
-        append_g3_corner(&mut builder, |x, y| {
-            (left + radius - radius * x, bottom - radius * y)
-        });
-        builder.line_to((left, top + radius));
-        append_g3_corner(&mut builder, |x, y| {
-            (left + radius * y, top + radius - radius * x)
-        });
+        let half_w = rect.width() as f64 / 2.0;
+        let half_h = rect.height() as f64 / 2.0;
+        let top = Octant::new(half_w, radius as f64);
+        let right = Octant::new(half_h, radius as f64);
+        let difference = half_w - half_h;
+        builder.move_to((rect.center_x(), rect.bottom()));
+        for (sx, sy, reverse) in [
+            (1.0, 1.0, false),
+            (1.0, -1.0, true),
+            (-1.0, -1.0, false),
+            (-1.0, 1.0, true),
+        ] {
+            let top_point = |p: CurvePoint| {
+                (
+                    rect.center_x() + (sx * p.0) as f32,
+                    rect.center_y() + (sy * (p.1 - difference)) as f32,
+                )
+            };
+            let right_point = |p: CurvePoint| {
+                (
+                    rect.center_x() + (sx * (p.1 + difference)) as f32,
+                    rect.center_y() + (sy * p.0) as f32,
+                )
+            };
+            if reverse {
+                right.append(&mut builder, right_point, false);
+                top.append(&mut builder, top_point, true);
+            } else {
+                top.append(&mut builder, top_point, false);
+                right.append(&mut builder, right_point, true);
+            }
+        }
         builder.close();
     }
 

--- a/src/window/app/frame.rs
+++ b/src/window/app/frame.rs
@@ -12,7 +12,7 @@ use crate::ui::expanded::music_view::{
 };
 use crate::utils::mouse::{
     get_global_cursor_pos, is_cursor_hidden, is_foreground_fullscreen, is_left_button_pressed,
-    is_point_in_g3_rounded_rect, is_point_in_rect,
+    is_point_in_continuous_rounded_rect, is_point_in_rect,
 };
 
 use super::{App, HideEdge, RIGHT_DRAG_THRESHOLD};
@@ -104,7 +104,7 @@ impl App {
         let offset_x = layout.offset_x;
         let current_island_x = layout.current_island_x;
         let current_island_y = layout.current_island_y;
-        let is_hovering_visible = is_point_in_g3_rounded_rect(
+        let is_hovering_visible = is_point_in_continuous_rounded_rect(
             rel_x as f64,
             rel_y as f64,
             current_island_x,
@@ -658,7 +658,11 @@ impl App {
             compact_content_h
         };
         let default_target_r = if self.expanded {
-            32.0 * self.config.expanded_scale
+            crate::utils::shape::expanded_island_radius(
+                self.config.expanded_width * self.config.expanded_scale,
+                default_target_h,
+                self.config.expanded_scale,
+            )
         } else {
             compact_content_h / 2.0
         };

--- a/src/window/app/input.rs
+++ b/src/window/app/input.rs
@@ -6,8 +6,8 @@ use crate::ui::expanded::music_view::{
     get_next_btn_rect, get_pause_btn_rect, get_prev_btn_rect, get_progress_bar_rect,
     trigger_cover_flip, trigger_next_click, trigger_pause_click, trigger_prev_click,
 };
-use crate::ui::widget::expanded::widget_grid_layout;
-use crate::utils::mouse::{is_point_in_g3_rounded_rect, is_point_in_rect};
+use crate::ui::widget::expanded::{widget_corner_radius, widget_grid_layout};
+use crate::utils::mouse::{is_point_in_continuous_rounded_rect, is_point_in_rect};
 
 use super::{App, IslandLayout, should_show_widget_view};
 
@@ -42,7 +42,7 @@ impl App {
                 let rel_x = px - self.geom.win_x;
                 let rel_y = py - self.geom.win_y;
                 let layout = self.compute_island_layout();
-                let is_hovering = is_point_in_g3_rounded_rect(
+                let is_hovering = is_point_in_continuous_rounded_rect(
                     rel_x as f64,
                     rel_y as f64,
                     layout.current_island_x,
@@ -86,7 +86,7 @@ impl App {
         let offset_x = layout.offset_x;
         let current_island_x = layout.current_island_x;
         let current_island_y = layout.current_island_y;
-        let is_hovering_visible = is_point_in_g3_rounded_rect(
+        let is_hovering_visible = is_point_in_continuous_rounded_rect(
             rel_x as f64,
             rel_y as f64,
             current_island_x,
@@ -239,13 +239,14 @@ impl App {
                         );
                         let (x, y, width, height) =
                             layout.footprint_rect(WidgetKind::Settings, entry.slot);
-                        is_point_in_rect(
+                        is_point_in_continuous_rounded_rect(
                             rel_x as f64,
                             rel_y as f64,
                             x as f64 + w - page_shift,
                             y as f64,
                             width as f64,
                             height as f64,
+                            widget_corner_radius(width, height, self.config.expanded_scale) as f64,
                         )
                     });
                 if settings_hit {


### PR DESCRIPTION
## Pre-submission checklist
- [x] I have read CONTRIBUTING.md and completed the required local checks
- [ ] Local and CI checks pass (local checks passed; CI pending)
- [x] I have completed a self-review

## Change type
- [x] `fix` Bug fix

## Scope
- [x] Application core
- [x] UI style or layout
- [x] Application behavior
- [x] Other: version 1.3.3 and redistribution license

## Description
### Summary
Use Apple-style continuous corners, keep expanded widgets clear of the island boundary, and soften the expanded shadow for 1.3.3.

### Motivation and context
The expanded island needs a smoother transition from straight edges into corners. Enlarging the corners also requires inset widget content and matching hit regions.

### Changes
- Adapt Flutter's BSD-licensed rounded-superellipse geometry, an approximation of SwiftUI continuous corners, and share the cached path between rendering and hit testing.
- Set the expanded corner radius to 48 logical pixels, inset widgets, and align widget previews with the continuous shape.
- Use a subtle expanded shadow and adjust music artwork, spacing, progress bar, and playback controls to the supplied reference.
- Bump Cargo package and lockfile version to 1.3.3 and include the Flutter license in installer staging.

### UI changes
Expanded music and widget views use continuous corners. Corner widget slots remain inset from the outer path. The shadow fades with expansion and hiding. Star and AirDrop controls are outside this change.

### Validation
Windows x86_64 MSVC: cargo check, clippy --workspace -- -D warnings, cargo fmt --all -- --check, and cargo build --release all passed. Executable FileVersion is 1.3.3. An external rendering harness was used to inspect compact, transition, expanded music, and all 18 widget slots at multiple scales; no tests or harness files are added to the repository. Live plugin/media and multi-monitor interaction still need maintainer acceptance testing. A signed installer was not built locally.

Based on 1b44fba387999107c2f05b552f7d89684aeee881, preserving the latest music-memory fix. This PR does not modify workflows or changelogs. A v1.3.3 Release draft will hold review artifacts; publication should wait for review and merge.